### PR TITLE
Don't pass an array to `supports`

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ version           '1.0.2'
 issues_url        'https://github.com/rhass/radarr/issues'
 source_url        'https://github.com/rhass/radarr'
 
-supports          %w(ubuntu debian)
+%w(ubuntu debian).each { |p| supports p }
 chef_version      '>= 13.0'
 
 gem 'nokogiri'


### PR DESCRIPTION
Thanks for the radarr cookbook. I attempted to upload it to my Chef server and received an error about invalid metadata.platforms:

```
aogail@chef-server:~/.chef/cookbooks/radarr$ knife cookbook upload radarr
Uploading radarr         [1.0.2]
ERROR: The data in your request was invalid
Response: Invalid key '["ubuntu", "debian"]' for metadata.platforms
```

I think this is because `supports` doesn't take an array of platforms.